### PR TITLE
Add failing wordwrap tests

### DIFF
--- a/tests/Unit/AnsiStringTest.php
+++ b/tests/Unit/AnsiStringTest.php
@@ -55,4 +55,37 @@ class AnsiStringTest extends TestCase
 		
 		$this->assertEquals($expected, (string) $parsed->wordwrap(10));
 	}
+
+	public function test_it_cuts_long_words_when_wrapping(): void
+	{
+		$input = "Cut long words";
+
+		$expected = <<<EOF
+		Cut
+		Lon
+		g w
+		ord
+		s
+		EOF;
+
+		$parsed = new AnsiString($input);
+
+		$this->assertEquals($expected, (string) $parsed->wordwrap(3, cut_long_words: true));
+	}
+
+	public function test_it_wraps_wide_characters(): void
+	{
+		$input = '🔥 🔥 あ あ';
+
+		$expected = <<<EOF
+		🔥
+		🔥
+		あ
+		あ
+		EOF;
+
+		$parsed = new AnsiString($input);
+
+		$this->assertEquals($expected, (string) $parsed->wordwrap(3));
+	}
 }


### PR DESCRIPTION
This PR adds tests for two failing `wordwrap` cases:

1. The `cut_long_words` parameter is not currently implemented.
2. Wrapping appears to be based on character length rather than width. In a terminal context, width is generally more desirable where characters like emojis are 2 columns wide rather than 1. The [`mb_strwidth`](https://www.php.net/manual/en/function.mb-strwidth) function can be used to find the width.